### PR TITLE
Fix storage info performance and skip unnecessary tree rebuilds

### DIFF
--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -152,10 +152,10 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 				// Load all chat files
 				const savedChatFiles = await dbManager.getAllChatFiles();
 
-				// Rebuild tree data for all files
+				// Use persisted tree data when available, only rebuild if missing
 				const processedChatFiles = savedChatFiles.map((file) => ({
 					...file,
-					treeData: buildTree(file.messages),
+					treeData: file.treeData?.length ? file.treeData : buildTree(file.messages),
 				}));
 
 				setChatFiles(processedChatFiles);


### PR DESCRIPTION
Replace getStorageUsage() which loaded all chat files and serialized them with JSON.stringify on every sidebar render. Now uses IDB count() and navigator.storage.estimate() instead. Also trust persisted treeData on startup rather than rebuilding every file's tree from scratch.