### PR TITLE
Add Landing Page as the app's front door

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 chats/
 .claude/
 CLAUDE.md
+
+# Local planning/context docs
+CONTEXT.md
+docs/

--- a/src/App.css
+++ b/src/App.css
@@ -63,6 +63,11 @@ body {
 	position: relative;
 }
 
+/* Landing Page owns the full viewport — drop the header/content grid rows */
+#root:has(.landing) {
+	display: block;
+}
+
 /* #region # Header */
 header {
 	grid-area: 1/1/2/2;
@@ -80,6 +85,10 @@ header {
 
 div#root:has(.mode-toggle-btn.claudecode.active) > header {
 	background: #ff5500;
+}
+
+.header-title-home {
+	cursor: pointer;
 }
 
 header > svg.sidebar-icon {
@@ -1288,9 +1297,8 @@ section.help {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	position: absolute;
-	width: 100%;
-	height: 100%;
+	position: fixed;
+	inset: 0;
 	scale: 0;
 	transform: scaleX(0.5);
 	transition: 1s;
@@ -1406,4 +1414,139 @@ section.help > div > a:hover {
 	text-decoration: underline;
 }
 
+/* #endregion */
+
+/* #region # Landing Page */
+.landing {
+	position: relative;
+	width: 100vw;
+	height: 100vh;
+	background: #1e1e1e;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	user-select: none;
+	overflow: hidden;
+	z-index: 1;
+}
+
+.landing-help {
+	position: absolute;
+	top: 30px;
+	right: 30px;
+	color: #ff9100;
+	cursor: pointer;
+	transition: 0.2s;
+}
+
+.landing-help:hover {
+	filter: drop-shadow(0 0 0.4rem #ff9100);
+}
+
+/* Hero sits ~1/3 down the page */
+.landing-hero {
+	margin-top: 22vh;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 1rem;
+	animation: landing-hero-in 400ms ease-out both;
+}
+
+.landing-icon {
+	width: 96px;
+	height: 96px;
+	object-fit: contain;
+}
+
+.landing-title {
+	margin: 0;
+	font-size: clamp(2.5rem, 6vw, 4.5rem);
+	font-weight: 700;
+	color: #ff9100;
+	text-align: center;
+}
+
+.landing-cards {
+	margin-top: 16vh;
+	display: flex;
+	justify-content: center;
+	align-items: stretch;
+	gap: 4rem;
+	flex-wrap: wrap;
+	padding: 0 2rem;
+}
+
+.landing-card {
+	min-width: 260px;
+	padding: 2.5rem 3rem;
+	font-size: 1.4rem;
+	font-weight: 600;
+	color: #f0f0f0;
+	background: #2a2a2a;
+	border: 2px solid #3a3a3a;
+	border-radius: 12px;
+	cursor: pointer;
+	transition: border-color 0.2s, transform 0.2s, background 0.2s;
+	animation: landing-card-in 450ms ease-out both;
+}
+
+/* Slight stagger between the two cards */
+.landing-card-1 {
+	animation-delay: 60ms;
+}
+
+.landing-card-2 {
+	animation-delay: 150ms;
+}
+
+.landing-card:hover {
+	border-color: #ff9100;
+	color: #ff9100;
+	background: #333;
+	transform: translateY(-4px);
+}
+
+@keyframes landing-hero-in {
+	from {
+		opacity: 0;
+		transform: translateY(-24px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes landing-card-in {
+	from {
+		opacity: 0;
+		transform: translateY(24px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@media screen and (max-width: 750px) {
+	.landing-cards {
+		flex-direction: column;
+		align-items: center;
+		gap: 1.5rem;
+		width: 100%;
+	}
+
+	.landing-card {
+		width: 100%;
+		max-width: 340px;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.landing-hero,
+	.landing-card {
+		animation: none;
+	}
+}
 /* #endregion */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { ChatProvider } from "./context/ChatContext";
+import { ChatProvider, useChatContext } from "./context/ChatContext";
 import Header from "./components/Header";
 import ChatTree from "./components/ChatTree";
 import DetailsPane from "./components/DetailsPane";
@@ -7,19 +7,39 @@ import type { ChatTreeRef } from "./components/ChatTree";
 import { useRef } from "react";
 import Sidebar from "./components/Sidebar";
 import HeatmapToggle from "./components/HeatmapToggle";
+import LandingPage from "./components/LandingPage";
+import Help from "./components/Help";
+
+// Renders the active View. Help is mounted once here so it is shared by both Views.
+function AppContent() {
+	const { view } = useChatContext();
+	const chatTreeRef = useRef<ChatTreeRef>(null);
+
+	return (
+		<>
+			{view === "home" ? (
+				<LandingPage />
+			) : (
+				<>
+					<Header />
+					<Search chatTreeRef={chatTreeRef} />
+					<HeatmapToggle />
+					<div className="content">
+						<Sidebar />
+						<ChatTree ref={chatTreeRef} />
+						<DetailsPane />
+					</div>
+				</>
+			)}
+			<Help />
+		</>
+	);
+}
 
 function App() {
-	const chatTreeRef = useRef<ChatTreeRef>(null);
 	return (
 		<ChatProvider>
-			<Header />
-			<Search chatTreeRef={chatTreeRef} />
-			<HeatmapToggle />
-			<div className="content">
-				<Sidebar />
-				<ChatTree ref={chatTreeRef} />
-				<DetailsPane />
-			</div>
+			<AppContent />
 		</ChatProvider>
 	);
 }

--- a/src/components/ChatTree.tsx
+++ b/src/components/ChatTree.tsx
@@ -2,7 +2,6 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
 import * as go from "gojs";
 import { useChatContext } from "../context/ChatContext";
-import Help from "./Help";
 //#endregion
 
 // 10 branch colours that suit white text on dark backgrounds
@@ -407,7 +406,6 @@ const ChatTree = forwardRef<ChatTreeRef, {}>((_, ref) => {
 					}}
 				/>
 			</div>
-			<Help />
 		</>
 	);
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import { Menu, ExternalLink } from "lucide-react";
 import { useChatContext } from "../context/ChatContext";
 
 const Header: React.FC = () => {
-	const { currentChatFile, sidebarOpen, toggleSidebar, renameChatFile, fileserverPassword, appMode, setAppMode, selectedDirectory } = useChatContext();
+	const { currentChatFile, sidebarOpen, toggleSidebar, renameChatFile, fileserverPassword, appMode, setAppMode, selectedDirectory, goHome } = useChatContext();
 	const [editingName, setEditingName] = useState("");
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -56,7 +56,7 @@ const Header: React.FC = () => {
 				</div>
 			)}
 
-			<h1>Branch Visualiser</h1>
+			<h1 className="header-title-home" onClick={goHome} title="Back to home">Branch Visualiser</h1>
 
 			{appMode === "claudeai" && currentChatFile && (
 				<>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { CircleQuestionMark } from "lucide-react";
+import { useChatContext } from "../context/ChatContext";
+
+const LandingPage: React.FC = () => {
+	const { fileserverPassword, isLoading, showHelp, setShowHelp, enterVisualiser } = useChatContext();
+
+	return (
+		<div className="landing">
+			<CircleQuestionMark className="landing-help" size={34} onClick={() => setShowHelp(!showHelp)} />
+
+			<div className="landing-hero">
+				<img src="/icon.png" alt="" className="landing-icon" />
+				<h1 className="landing-title">Branch Visualiser</h1>
+			</div>
+
+			{/* Cards render only after loading completes so the Claude Code card doesn't pop in once the password loads */}
+			{!isLoading && (
+				<div className="landing-cards">
+					<button className="landing-card landing-card-1" onClick={() => enterVisualiser("claudeai")}>
+						Browse Claude.ai Chats
+					</button>
+					{fileserverPassword && (
+						<button className="landing-card landing-card-2" onClick={() => enterVisualiser("claudecode")}>
+							Browse Claude Code Sessions
+						</button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default LandingPage;

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -41,8 +41,10 @@ interface Message {
 }
 
 type AppMode = "claudeai" | "claudecode";
+type View = "home" | "visualiser";
 
 interface ChatContextType {
+	view: View;
 	chatFiles: ChatFile[];
 	currentChatFile: ChatFile | null;
 	allMessages: Message[];
@@ -72,6 +74,8 @@ interface ChatContextType {
 	renameChatFile: (id: string, newDisplayName: string) => Promise<void>;
 	setAppMode: (mode: AppMode) => void;
 	setSelectedDirectory: (dir: string | null) => void;
+	goHome: () => void;
+	enterVisualiser: (mode: AppMode) => void;
 }
 //#endregion
 
@@ -104,6 +108,8 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 	const [fileserverPassword, setFileserverPasswordState] = useState<string | null>(null);
 	const [appMode, setAppModeState] = useState<AppMode>("claudeai");
 	const [selectedDirectory, setSelectedDirectoryState] = useState<string | null>(null);
+	// Top-level View. Always starts on the Landing Page ("home"); never persisted.
+	const [view, setView] = useState<View>("home");
 	//#endregion
 
 	//#region Derived State
@@ -248,13 +254,17 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
 				setChatFiles(processedChatFiles);
 
-				// Load current chat file setting
+				// Load current chat file setting (restored behind the home view; a Mode Card reveals it)
 				const currentChatId = await dbManager.getSetting("currentChatId");
 				if (currentChatId && processedChatFiles.length > 0) {
 					const currentFile = processedChatFiles.find((file) => file.id === currentChatId);
 					console.log(`Current chat file ID: ${currentChatId}`);
 					if (currentFile) setCurrentChatFileState(currentFile);
-				} else setSidebarOpen(true);
+				}
+
+				// Load last selected directory (Claude Code Mode Card restores this)
+				const savedDirectory = await dbManager.getSetting("selectedDirectory");
+				if (savedDirectory) setSelectedDirectoryState(savedDirectory);
 
 				// Load fileserver password
 				const savedPassword = await dbManager.getPassword();
@@ -458,6 +468,20 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 	const setSelectedDirectory = (dir: string | null) => {
 		setSelectedDirectoryState(dir);
 		setCurrentlySelectedMessage(null);
+		// Persist so the Claude Code Mode Card can restore the last directory. Mirrors currentChatId.
+		dbManager.saveSetting("selectedDirectory", dir).catch((error) => console.error("Failed to persist selectedDirectory:", error));
+	};
+	//#endregion
+
+	//#region View Management
+	// Return to the Landing Page — a pure View switch, no selection reset.
+	const goHome = () => setView("home");
+
+	// Enter the Visualiser in the given Mode: set the mode explicitly and open the sidebar.
+	const enterVisualiser = (mode: AppMode) => {
+		setAppModeState(mode);
+		setSidebarOpen(true);
+		setView("visualiser");
 	};
 	//#endregion
 
@@ -472,6 +496,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 	return (
 		<ChatContext.Provider
 			value={{
+				view,
 				chatFiles,
 				currentChatFile,
 				allMessages: appMode === "claudeai"
@@ -503,6 +528,8 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 				renameChatFile,
 				setAppMode,
 				setSelectedDirectory,
+				goHome,
+				enterVisualiser,
 			}}
 		>
 			{children}


### PR DESCRIPTION
## Summary

Adds a **Landing Page** as the app's entry view. On every fresh load the app now shows the Landing Page (icon, hero title, Mode Cards) instead of dropping straight into the Visualiser. Choosing a Mode Card enters the Visualiser in that mode; clicking the header title returns home.

## Changes

- **`view` state** (`"home" | "visualiser"`, default `"home"`, not persisted) in `ChatContext`, with `goHome()` / `enterVisualiser(mode)` helpers.
- **`selectedDirectory` now persisted** as a setting so the Claude Code Mode Card can restore the last directory (mirrors `currentChatId`).
- **New `LandingPage` component** — app icon, hero title, Mode Cards (Claude.ai always shown; Claude Code shown only when a fileserver password is set), and a Help icon. Cards render only after loading completes.
- **`App.tsx`** switches on `view`; **`Help` is hoisted here** so it's mounted once and shared by both views (moved out of `ChatTree`).
- **Header title is clickable** → returns to the Landing Page (pure view switch, no selection reset).
- **CSS**: dark-grey landing layout, hero fade-down + card fade-rise animations with stagger, mobile stacking, reduced-motion guard. The Help overlay is now `position: fixed; inset: 0` so it reliably covers the viewport in both views.

## Verification

- `npx tsc -b` clean, `npm run build` passes, lint shows no new issues.
- Driven in the browser: landing renders, cards enter the Visualiser, header title returns home, and the Help modal opens over both views.

## Notes

Local planning docs (`CONTEXT.md`, `docs/`) are intentionally gitignored rather than tracked.