### PR TITLE
Fix Landing Page icon 404 under the /branches/ prod base

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -10,7 +10,8 @@ const LandingPage: React.FC = () => {
 			<CircleQuestionMark className="landing-help" size={34} onClick={() => setShowHelp(!showHelp)} />
 
 			<div className="landing-hero">
-				<img src="/icon.png" alt="" className="landing-icon" />
+				{/* BASE_URL (trailing slash) keeps this correct under the /branches/ prod base */}
+				<img src={`${import.meta.env.BASE_URL}icon.png`} alt="" className="landing-icon" />
 				<h1 className="landing-title">Branch Visualiser</h1>
 			</div>
 


### PR DESCRIPTION
## Problem

In production the app is served under `base: '/branches/'` (see `vite.config.ts`), but the Landing Page hardcoded `<img src="/icon.png">`. Vite rewrites base-relative URLs in `index.html` at build time (which is why the favicon correctly points at `/branches/icon.png`), but it does **not** rewrite plain string literals inside components. So the hero icon requested `/icon.png` and 404'd in prod.

## Fix

Reference the icon through `import.meta.env.BASE_URL`, which Vite inlines to the configured base (`/branches/` in prod, `/` in dev). `BASE_URL` includes a trailing slash, so the icon is `` `${import.meta.env.BASE_URL}icon.png` ``.

## Verification

Production build (`NODE_ENV=production npm run build`) now emits `/branches/icon.png` in the bundled JS, matching the favicon in the built `index.html`. Typecheck and build pass.