### PR TITLE
Add search to the Landing Page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -643,6 +643,37 @@ code {
 	background: #7b38ac;
 }
 
+/* Landing Page variant: sits centred beneath the Mode Cards instead of pinned bottom-left */
+.search-button-landing {
+	position: relative;
+	/* Clear the base button's bottom-left pinning, which still offsets a relative element */
+	left: 0;
+	bottom: 0;
+	margin-top: 6vh;
+	align-self: center;
+	color: #ff9100;
+	/* Sits under the open panel, matching how the overlay covers the page in the Visualiser */
+	z-index: 1;
+	animation: landing-card-in 450ms ease-out both;
+	animation-delay: 240ms;
+}
+
+.search-button-landing:hover {
+	background: rgba(255, 145, 0, 0.12);
+}
+
+/* The Landing Page has no header, so the open panel spans the full page height */
+.search-button-landing.active + .search-container {
+	top: 0;
+	height: 100%;
+}
+
+/* No tabs on the Landing Page — round off the top of the input row instead */
+.search-dropdown-landing .search-input-container {
+	border-top-left-radius: 2rem;
+	border-top-right-radius: 2rem;
+}
+
 /* #region # Heatmap Toggle */
 .heatmap-button {
 	position: fixed;
@@ -1472,14 +1503,15 @@ section.help > div > a:hover {
 	display: flex;
 	justify-content: center;
 	align-items: stretch;
-	gap: 4rem;
+	gap: 2rem;
 	flex-wrap: wrap;
 	padding: 0 2rem;
 }
 
 .landing-card {
-	min-width: 260px;
-	padding: 2.5rem 3rem;
+	/* Fixed width so both cards match regardless of label length */
+	width: 26rem;
+	padding: 2.5rem 1.5rem;
 	font-size: 1.4rem;
 	font-weight: 600;
 	color: #f0f0f0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ function AppContent() {
 	return (
 		<>
 			{view === "home" ? (
-				<LandingPage />
+				<LandingPage chatTreeRef={chatTreeRef} />
 			) : (
 				<>
 					<Header />

--- a/src/components/ChatTree.tsx
+++ b/src/components/ChatTree.tsx
@@ -26,7 +26,8 @@ function getBranchColor(branch: string, branchIndex: Map<string, number>): strin
 }
 
 interface ChatTreeRef {
-	scrollToMessage: (messageUuid: string) => void;
+	// Returns false when the node is not in the diagram yet, so callers can retry
+	scrollToMessage: (messageUuid: string) => boolean;
 }
 
 const ChatTree = forwardRef<ChatTreeRef, {}>((_, ref) => {
@@ -383,13 +384,13 @@ const ChatTree = forwardRef<ChatTreeRef, {}>((_, ref) => {
 
 	useImperativeHandle(ref, () => ({
 		scrollToMessage: (messageUuid: string) => {
-			if (diagramInstanceRef.current) {
-				const node = diagramInstanceRef.current.findNodeForKey(messageUuid);
-				if (node) {
-					diagramInstanceRef.current.select(node);
-					diagramInstanceRef.current.centerRect(node.actualBounds);
-				}
-			}
+			if (!diagramInstanceRef.current) return false;
+			const node = diagramInstanceRef.current.findNodeForKey(messageUuid);
+			if (!node) return false;
+
+			diagramInstanceRef.current.select(node);
+			diagramInstanceRef.current.centerRect(node.actualBounds);
+			return true;
 		},
 	}));
 	//#endregion

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 import { CircleQuestionMark } from "lucide-react";
 import { useChatContext } from "../context/ChatContext";
+import Search from "./Search";
+import type { ChatTreeRef } from "./ChatTree";
 
-const LandingPage: React.FC = () => {
+interface LandingPageProps {
+	// Shared with the Visualiser so a search result can be centred once the tree mounts
+	chatTreeRef: React.RefObject<ChatTreeRef | null>;
+}
+
+const LandingPage: React.FC<LandingPageProps> = ({ chatTreeRef }) => {
 	const { fileserverPassword, isLoading, showHelp, setShowHelp, enterVisualiser } = useChatContext();
 
 	return (
@@ -28,6 +35,8 @@ const LandingPage: React.FC = () => {
 					)}
 				</div>
 			)}
+
+			{!isLoading && <Search chatTreeRef={chatTreeRef} landing />}
 		</div>
 	);
 };

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -6,7 +6,10 @@ import type { ChatTreeRef } from "./ChatTree";
 //#endregion
 
 interface SearchProps {
-	chatTreeRef: React.RefObject<ChatTreeRef | null>;
+	// Omitted on the Landing Page, where no tree is mounted yet
+	chatTreeRef?: React.RefObject<ChatTreeRef | null>;
+	// Landing Page variant: centred under the Mode Cards, always searches all chats
+	landing?: boolean;
 }
 
 interface SearchResult {
@@ -16,15 +19,16 @@ interface SearchResult {
 	isTitleMatch?: boolean;
 }
 
-const Search: React.FC<SearchProps> = ({ chatTreeRef }) => {
+const Search: React.FC<SearchProps> = ({ chatTreeRef, landing = false }) => {
 	//#region State
 	const [isOpen, setIsOpen] = useState(false);
-	const [searchMode, setSearchMode] = useState<"current" | "all">("current");
+	// The Landing Page has no current chat, so it is locked to the all-chats search
+	const [searchMode, setSearchMode] = useState<"current" | "all">(landing ? "all" : "current");
 	const [searchQuery, setSearchQuery] = useState("");
 	const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
 	const [isSearching, setIsSearching] = useState(false);
 	const [selectedIndex, setSelectedIndex] = useState(-1);
-	const { allMessages, chatFiles, claudeCodeFiles, setCurrentChatFile, setSelectedDirectory, setAppMode, setCurrentlySelectedMessage, setSidebarOpen } = useChatContext();
+	const { allMessages, chatFiles, claudeCodeFiles, setCurrentChatFile, setSelectedDirectory, setAppMode, setCurrentlySelectedMessage, setSidebarOpen, enterVisualiser } = useChatContext();
 	const inputRef = useRef<HTMLInputElement>(null);
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const workerRef = useRef<Worker | null>(null);
@@ -48,8 +52,8 @@ const Search: React.FC<SearchProps> = ({ chatTreeRef }) => {
 
 	//#region Search Logic
 	const performSearch = (query: string) => {
-		// No query (or too short), or no messages
-		if (query.trim().length < 3 || !allMessages.length) {
+		// Too short to search. The all-chats path has no allMessages requirement — it reads chatFiles directly.
+		if (query.trim().length < 3 || (searchMode === "current" && !allMessages.length)) {
 			setSearchResults([]);
 			setIsSearching(false);
 			return;
@@ -149,13 +153,16 @@ const Search: React.FC<SearchProps> = ({ chatTreeRef }) => {
 	//#endregion
 
 	//#region Keyboard Shortcut and Click Outside Handlers
+	// The Landing Page searches across files, so it only needs files present — not a loaded chat
+	const canSearch = landing ? chatFiles.length > 0 : allMessages.length > 0;
+
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
 			if (e.key === "s" || e.key === "S") {
 				// Only trigger if not typing in an input/textarea
 				if (document.activeElement?.tagName !== "INPUT" && document.activeElement?.tagName !== "TEXTAREA") {
 					e.preventDefault();
-					if (!isOpen && allMessages.length > 0) {
+					if (!isOpen && canSearch) {
 						openSearch();
 					}
 				}
@@ -175,7 +182,7 @@ const Search: React.FC<SearchProps> = ({ chatTreeRef }) => {
 			document.removeEventListener("keydown", handleKeyDown);
 			document.removeEventListener("mousedown", handleClickOutside);
 		};
-	}, [isOpen, allMessages.length]);
+	}, [isOpen, canSearch]);
 	//#endregion
 
 	//#region Event Handlers
@@ -206,7 +213,28 @@ const Search: React.FC<SearchProps> = ({ chatTreeRef }) => {
 		}
 	};
 
+	// Poll briefly for the tree to mount and render the target node, then centre on it
+	const scrollWhenReady = (messageUuid: string, attemptsLeft = 20) => {
+		if (chatTreeRef?.current?.scrollToMessage(messageUuid)) return;
+		if (attemptsLeft > 0) {
+			setTimeout(() => scrollWhenReady(messageUuid, attemptsLeft - 1), 100);
+		}
+	};
+
 	const handleResultClick = async (result: SearchResult) => {
+		const revealMessage = () => {
+			setCurrentlySelectedMessage(result.message);
+
+			// Coming from the Landing Page the tree mounts and loads its data only after the View
+			// switch, so retry briefly until the node exists rather than scrolling into an empty diagram.
+			if (landing) {
+				scrollWhenReady(result.message.uuid);
+				return;
+			}
+
+			chatTreeRef?.current?.scrollToMessage(result.message.uuid);
+		};
+
 		if (searchMode === "all") {
 			const fileName = (result.message as any)._chatFileName;
 			const targetChatFile = chatFiles.find((cf) => cf.name === fileName);
@@ -215,36 +243,22 @@ const Search: React.FC<SearchProps> = ({ chatTreeRef }) => {
 				// Navigate to the directory containing this session, switching mode if needed
 				const ccFile = claudeCodeFiles.find((f) => f.name === fileName);
 				if (ccFile) {
-					setAppMode("claudecode");
+					if (landing) enterVisualiser("claudecode");
+					else setAppMode("claudecode");
 					setSelectedDirectory(ccFile.projectPath);
-					setTimeout(() => {
-						setCurrentlySelectedMessage(result.message);
-						if (chatTreeRef.current) {
-							chatTreeRef.current.scrollToMessage(result.message.uuid);
-						}
-					}, 100);
+					setTimeout(revealMessage, 100);
 				}
 			} else if (targetChatFile) {
-				setAppMode("claudeai");
+				if (landing) enterVisualiser("claudeai");
+				else setAppMode("claudeai");
 				await setCurrentChatFile(targetChatFile);
-				setTimeout(() => {
-					setCurrentlySelectedMessage(result.message);
-					if (chatTreeRef.current) {
-						chatTreeRef.current.scrollToMessage(result.message.uuid);
-					}
-				}, 100);
+				setTimeout(revealMessage, 100);
 			} else {
-				setCurrentlySelectedMessage(result.message);
-				if (chatTreeRef.current) {
-					chatTreeRef.current.scrollToMessage(result.message.uuid);
-				}
+				revealMessage();
 			}
 		} else {
 			// Current chat / current directory search
-			setCurrentlySelectedMessage(result.message);
-			if (chatTreeRef.current) {
-				chatTreeRef.current.scrollToMessage(result.message.uuid);
-			}
+			revealMessage();
 		}
 
 		handleClose();
@@ -337,23 +351,32 @@ const Search: React.FC<SearchProps> = ({ chatTreeRef }) => {
 
 	return (
 		<>
-			{allMessages.length > 0 && <SearchIcon className={`search-button${isOpen ? " active" : ""}`} size={60} onClick={handleSearchClick} />}
+			{canSearch && (
+				<SearchIcon
+					className={`search-button${landing ? " search-button-landing" : ""}${isOpen ? " active" : ""}`}
+					size={60}
+					onClick={handleSearchClick}
+				/>
+			)}
 			<div className="search-container">
-				<div className="search-dropdown" ref={dropdownRef}>
-					<div className="search-tabs">
-						<button className={`search-tab ${searchMode === "current" ? "active" : ""}`} onClick={() => setSearchMode("current")}>
-							Current Chat
-						</button>
-						<button className={`search-tab ${searchMode === "all" ? "active" : ""}`} onClick={() => setSearchMode("all")}>
-							All Chats
-						</button>
-					</div>
+				<div className={`search-dropdown${landing ? " search-dropdown-landing" : ""}`} ref={dropdownRef}>
+					{/* The Landing Page has no current chat to scope to, so it always searches all chats */}
+					{!landing && (
+						<div className="search-tabs">
+							<button className={`search-tab ${searchMode === "current" ? "active" : ""}`} onClick={() => setSearchMode("current")}>
+								Current Chat
+							</button>
+							<button className={`search-tab ${searchMode === "all" ? "active" : ""}`} onClick={() => setSearchMode("all")}>
+								All Chats
+							</button>
+						</div>
+					)}
 
 					<div className="search-input-container">
 						<input
 							ref={inputRef}
 							type="text"
-							placeholder="Search messages..."
+							placeholder={landing ? "Search all chats..." : "Search messages..."}
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
 							onKeyDown={handleKeyDown}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,13 +25,13 @@ const Sidebar: React.FC = () => {
 		showHelp,
 		setShowHelp,
 		fileserverPassword,
-		setFileserverPassword,
 		appMode,
+		isSyncing,
+		syncFromFileserver,
 	} = useChatContext();
 
 	const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
 	const [storageInfo, setStorageInfo] = useState<{ count: number; sizeEstimate: string }>({ count: 0, sizeEstimate: "0MB" });
-	const [isSyncing, setIsSyncing] = useState(false);
 	const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
 	//#endregion
 
@@ -48,16 +48,7 @@ const Sidebar: React.FC = () => {
 	}, [chatFiles, isLoading, getStorageInfo]);
 	//#endregion
 
-	//#region Auto-sync on initial load
-	const hasSyncedRef = useRef(false);
-	useEffect(() => {
-		if (!isLoading && fileserverPassword && !hasSyncedRef.current) {
-			hasSyncedRef.current = true;
-			console.log("[Sync] Auto-syncing on page load");
-			syncFromFileserver();
-		}
-	}, [isLoading, fileserverPassword]);
-	//#endregion
+	// Sync lives in ChatContext so it also runs on the Landing Page, where search needs the latest files
 
 	const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
 		const file = event.target.files?.[0];
@@ -102,120 +93,6 @@ const Sidebar: React.FC = () => {
 		if (inputRef) {
 			inputRef.value = "";
 		}
-	};
-	//#endregion
-
-	//#region Sync from Fileserver
-	const syncFromFileserver = async () => {
-		if (!fileserverPassword) {
-			alert("Fileserver password not set. Open the help section to set it up.");
-			return;
-		}
-
-		setIsSyncing(true);
-		try {
-			await syncDirectory("", fileserverPassword);
-			await syncDirectory("claude-code/", fileserverPassword);
-			console.log("[Sync] All syncs complete");
-		} catch (error) {
-			console.error("[Sync] Failed:", error);
-			alert("Sync failed. Check console for details.");
-		} finally {
-			setIsSyncing(false);
-		}
-	};
-
-	const syncDirectory = async (subDir: string, password: string) => {
-		const baseUrl = `https://files.server-chris.com/projects/claude-branch-visualiser/${subDir}`;
-		const isClaudeCode = subDir === "claude-code/";
-
-		const response = await fetch(`${baseUrl}?ls&pw=${encodeURIComponent(password)}`);
-		if (!response.ok) {
-			if (response.status === 401 || response.status === 403) {
-				alert("Invalid password. Please set the correct password in the help section.");
-				await setFileserverPassword(null);
-			}
-			throw new Error(`Failed to fetch file list from ${subDir}: ${response.status}`);
-		}
-
-		const data = await response.json();
-		const serverFiles = data.files || [];
-
-		console.log(`[Sync] Found ${serverFiles.length} files in ${subDir || "root"}`);
-
-		// Create a map of existing files by name for quick lookup
-		const existingFilesMap = new Map(chatFiles.map((file) => [file.name, file]));
-
-		let downloadedCount = 0;
-		let updatedCount = 0;
-		let skippedCount = 0;
-
-		for (const serverFile of serverFiles) {
-			const fileName = serverFile.href;
-			const serverTimestamp = serverFile.tags[".up_at"];
-
-			if (serverFile.ext !== "json") {
-				console.log(`[Sync] Skipping non-JSON file: ${fileName}`);
-				continue;
-			}
-
-			// For Claude Code files, store with the subdir prefix to avoid name collisions
-			const storeKey = isClaudeCode ? `claude-code/${fileName}` : fileName;
-			const existingFile = existingFilesMap.get(storeKey);
-
-			let shouldDownload = false;
-			if (!existingFile) {
-				console.log(`[Sync] New file detected: ${storeKey}`);
-				shouldDownload = true;
-			} else {
-				const existingTimestamp = new Date(existingFile.lastUpdated).getTime() / 1000;
-				if (serverTimestamp > existingTimestamp) {
-					console.log(`[Sync] File has updates: ${storeKey}`);
-					shouldDownload = true;
-				} else {
-					skippedCount++;
-				}
-			}
-
-			if (shouldDownload) {
-				try {
-					const fileUrl = `${baseUrl}${encodeURIComponent(fileName)}?pw=${encodeURIComponent(password)}&dl`;
-					const fileResponse = await fetch(fileUrl);
-
-					if (!fileResponse.ok) {
-						console.error(`[Sync] Failed to download ${storeKey}: ${fileResponse.status}`);
-						continue;
-					}
-
-					const fileData = await fileResponse.json();
-
-					if (!fileData.chat_messages) {
-						console.warn(`[Sync] File ${storeKey} missing chat_messages, skipping`);
-						continue;
-					}
-
-					if (isClaudeCode) {
-						const projectPath = fileData.project?.path || "unknown";
-						const gitBranch = fileData.project?.git_branch || "HEAD";
-						await addOrUpdateChatFile(storeKey, fileData.chat_messages, false, fileData.uuid, "CLAUDE_CODE", projectPath, gitBranch);
-					} else {
-						await addOrUpdateChatFile(storeKey, fileData.chat_messages, false, fileData.uuid);
-					}
-
-					if (existingFile) {
-						updatedCount++;
-						console.log(`[Sync] ✓ Updated: ${storeKey}`);
-					} else {
-						downloadedCount++;
-						console.log(`[Sync] ✓ Downloaded: ${storeKey}`);
-					}
-				} catch (error) {
-					console.error(`[Sync] Error processing ${storeKey}:`, error);
-				}
-			}
-		}
-
-		console.log(`[Sync] ${subDir || "root"} — Downloaded: ${downloadedCount}, Updated: ${updatedCount}, Skipped: ${skippedCount}`);
 	};
 	//#endregion
 
@@ -585,7 +462,7 @@ const Sidebar: React.FC = () => {
 				<h2>{appMode === "claudecode" ? "Directories" : "Chat Files"}</h2>
 				<div className="sidebar-header-actions">
 					{fileserverPassword && (
-						<button className="sidebar-header-btn sync" onClick={syncFromFileserver} disabled={isSyncing} title="Sync from fileserver">
+						<button className="sidebar-header-btn sync" onClick={() => syncFromFileserver()} disabled={isSyncing} title="Sync from fileserver">
 							<RefreshCw size={16} className={isSyncing ? "spinning" : ""} />
 						</button>
 					)}

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useMemo } from "react";
+import React, { createContext, useContext, useState, useEffect, useMemo, useRef } from "react";
 import { dbManager, type ChatFile, type ClaudeCodeChatFile } from "../utils/indexedDB";
 
 //#region Interfaces
@@ -55,6 +55,8 @@ interface ChatContextType {
 	showHelp: boolean;
 	heatmapEnabled: boolean;
 	fileserverPassword: string | null;
+	isSyncing: boolean;
+	syncFromFileserver: (options?: { silent?: boolean }) => Promise<void>;
 	appMode: AppMode;
 	selectedDirectory: string | null;
 	claudeAiFiles: ChatFile[];
@@ -106,6 +108,7 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 	const [showHelp, setShowHelp] = useState<boolean>(false);
 	const [heatmapEnabled, setHeatmapEnabled] = useState<boolean>(false);
 	const [fileserverPassword, setFileserverPasswordState] = useState<string | null>(null);
+	const [isSyncing, setIsSyncing] = useState(false);
 	const [appMode, setAppModeState] = useState<AppMode>("claudeai");
 	const [selectedDirectory, setSelectedDirectoryState] = useState<string | null>(null);
 	// Top-level View. Always starts on the Landing Page ("home"); never persisted.
@@ -283,6 +286,138 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
 		loadInitialData();
 	}, []);
+	//#endregion
+
+	//#region Fileserver Sync
+	// Mirror of chatFiles for the sync, which compares timestamps across two sequential
+	// directory passes and would otherwise read a stale state snapshot on the second pass.
+	const chatFilesRef = useRef<ChatFile[]>([]);
+	useEffect(() => {
+		chatFilesRef.current = chatFiles;
+	}, [chatFiles]);
+
+	const syncDirectory = async (subDir: string, password: string, silent: boolean) => {
+		const baseUrl = `https://files.server-chris.com/projects/claude-branch-visualiser/${subDir}`;
+		const isClaudeCode = subDir === "claude-code/";
+
+		const response = await fetch(`${baseUrl}?ls&pw=${encodeURIComponent(password)}`);
+		if (!response.ok) {
+			if (response.status === 401 || response.status === 403) {
+				if (!silent) alert("Invalid password. Please set the correct password in the help section.");
+				await setFileserverPassword(null);
+			}
+			throw new Error(`Failed to fetch file list from ${subDir}: ${response.status}`);
+		}
+
+		const data = await response.json();
+		const serverFiles = data.files || [];
+
+		console.log(`[Sync] Found ${serverFiles.length} files in ${subDir || "root"}`);
+
+		let downloadedCount = 0;
+		let updatedCount = 0;
+		let skippedCount = 0;
+
+		for (const serverFile of serverFiles) {
+			const fileName = serverFile.href;
+			const serverTimestamp = serverFile.tags[".up_at"];
+
+			if (serverFile.ext !== "json") {
+				console.log(`[Sync] Skipping non-JSON file: ${fileName}`);
+				continue;
+			}
+
+			// For Claude Code files, store with the subdir prefix to avoid name collisions
+			const storeKey = isClaudeCode ? `claude-code/${fileName}` : fileName;
+			const existingFile = chatFilesRef.current.find((file) => file.name === storeKey);
+
+			let shouldDownload = false;
+			if (!existingFile) {
+				console.log(`[Sync] New file detected: ${storeKey}`);
+				shouldDownload = true;
+			} else {
+				const existingTimestamp = new Date(existingFile.lastUpdated).getTime() / 1000;
+				if (serverTimestamp > existingTimestamp) {
+					console.log(`[Sync] File has updates: ${storeKey}`);
+					shouldDownload = true;
+				} else {
+					skippedCount++;
+				}
+			}
+
+			if (shouldDownload) {
+				try {
+					const fileUrl = `${baseUrl}${encodeURIComponent(fileName)}?pw=${encodeURIComponent(password)}&dl`;
+					const fileResponse = await fetch(fileUrl);
+
+					if (!fileResponse.ok) {
+						console.error(`[Sync] Failed to download ${storeKey}: ${fileResponse.status}`);
+						continue;
+					}
+
+					const fileData = await fileResponse.json();
+
+					if (!fileData.chat_messages) {
+						console.warn(`[Sync] File ${storeKey} missing chat_messages, skipping`);
+						continue;
+					}
+
+					if (isClaudeCode) {
+						const projectPath = fileData.project?.path || "unknown";
+						const gitBranch = fileData.project?.git_branch || "HEAD";
+						await addOrUpdateChatFile(storeKey, fileData.chat_messages, false, fileData.uuid, "CLAUDE_CODE", projectPath, gitBranch);
+					} else {
+						await addOrUpdateChatFile(storeKey, fileData.chat_messages, false, fileData.uuid);
+					}
+
+					if (existingFile) {
+						updatedCount++;
+						console.log(`[Sync] ✓ Updated: ${storeKey}`);
+					} else {
+						downloadedCount++;
+						console.log(`[Sync] ✓ Downloaded: ${storeKey}`);
+					}
+				} catch (error) {
+					console.error(`[Sync] Error processing ${storeKey}:`, error);
+				}
+			}
+		}
+
+		console.log(`[Sync] ${subDir || "root"} — Downloaded: ${downloadedCount}, Updated: ${updatedCount}, Skipped: ${skippedCount}`);
+	};
+
+	// `silent` suppresses alerts for the automatic sync, which can run on the Landing Page
+	const syncFromFileserver = async (options?: { silent?: boolean }) => {
+		const silent = options?.silent ?? false;
+
+		if (!fileserverPassword) {
+			if (!silent) alert("Fileserver password not set. Open the help section to set it up.");
+			return;
+		}
+
+		setIsSyncing(true);
+		try {
+			await syncDirectory("", fileserverPassword, silent);
+			await syncDirectory("claude-code/", fileserverPassword, silent);
+			console.log("[Sync] All syncs complete");
+		} catch (error) {
+			console.error("[Sync] Failed:", error);
+			if (!silent) alert("Sync failed. Check console for details.");
+		} finally {
+			setIsSyncing(false);
+		}
+	};
+
+	// Auto-sync once the password is known, regardless of which View is showing, so
+	// searching from the Landing Page covers the latest files.
+	const hasSyncedRef = useRef(false);
+	useEffect(() => {
+		if (!isLoading && fileserverPassword && !hasSyncedRef.current) {
+			hasSyncedRef.current = true;
+			console.log("[Sync] Auto-syncing on page load");
+			syncFromFileserver({ silent: true });
+		}
+	}, [isLoading, fileserverPassword]);
 	//#endregion
 
 	//#region Active Tree Data
@@ -509,6 +644,8 @@ export const ChatProvider: React.FC<{ children: React.ReactNode }> = ({ children
 				showHelp,
 				heatmapEnabled,
 				fileserverPassword,
+				isSyncing,
+				syncFromFileserver,
 				appMode,
 				selectedDirectory,
 				claudeAiFiles,


### PR DESCRIPTION
Adds the search icon to the Landing Page, centred beneath the Mode Cards, with the same open/close and keyboard behaviour as the Visualiser (click to toggle, `S` shortcut, click-outside and `Esc` to close, arrow-key navigation, 3-character minimum, 300ms debounce).

## Behaviour on the Landing Page

- **Always searches all chats.** There is no current chat to scope to, so the mode tabs are hidden and it is locked to the all-chats worker search.
- **Picking a result enters the Visualiser** in the mode that owns the matching file (Claude.ai or Claude Code), rather than only switching mode.

## Fixes needed to make that work

- `performSearch` bailed out whenever `allMessages` was empty, which is always the case on the Landing Page. That guard now applies only to the current-chat path; the all-chats path reads `chatFiles` directly.
- `scrollToMessage` was a silent no-op when the tree had not rendered the target node yet. It now returns whether it found the node, so the Landing Page can retry briefly until the tree mounts after the View switch — otherwise a result would be selected without the tree scrolling to it.

## Fileserver sync

Moved out of `Sidebar` (which only mounts inside the Visualiser) into `ChatContext`, so it also runs on the Landing Page where search needs the latest files. The Sidebar's manual sync button and spinner now share that single implementation.

Two details worth noting:

- The automatic sync runs silently, so a bad password or a failed request cannot throw `alert()` dialogs at someone sitting on the Landing Page. The manual button still alerts as before.
- The sync compares server timestamps against local files across two sequential directory passes. Reading `chatFiles` state directly would go stale on the second pass, so it reads through a ref tracking the latest value.

## Layout

The Mode Cards were sized to their own text, so they had unequal widths and sat slightly off-centre. They now use a fixed matching width and stay symmetric about the same axis as the title and the search icon.

## Verification

`npx tsc -b` clean, production build succeeds, and lint counts are unchanged from `master` (50 problems before and after, all pre-existing `no-explicit-any`). Layout confirmed visually in the dev server.